### PR TITLE
Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0 a.o

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-F401RE.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-F401RE.dbgconf
@@ -1,0 +1,41 @@
+// File: STM32F401xBCDE_411xCE.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32F401xB/C STM32F401xD/E reference manual (RM0368)
+//       refer to STM32F401xB/C STM32F401xD/E datasheet
+//       refer to STM32F411xC/E               reference manual (RM0383)
+//       refer to STM32F411xC/E               datasheet
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3_SMBUS_TIMEOUT   <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_SMBUS_TIMEOUT   <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> RTC stopped when core is halted
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 counter stopped when core is halted
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM11_STOP           <i> TIM11 counter stopped when core is halted
+//   <o.17> DBG_TIM10_STOP           <i> TIM10 counter stopped when core is halted
+//   <o.16> DBG_TIM9_STOP            <i> TIM9 counter stopped when core is halted
+//   <o.0>  DBG_TIM1_STOP            <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-F401RE.dbgconf.base@0.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-F401RE.dbgconf.base@0.0.0
@@ -1,0 +1,41 @@
+// File: STM32F401xBCDE_411xCE.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32F401xB/C STM32F401xD/E reference manual (RM0368)
+//       refer to STM32F401xB/C STM32F401xD/E datasheet
+//       refer to STM32F411xC/E               reference manual (RM0383)
+//       refer to STM32F411xC/E               datasheet
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3_SMBUS_TIMEOUT   <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_SMBUS_TIMEOUT   <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> RTC stopped when core is halted
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 counter stopped when core is halted
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM11_STOP           <i> TIM11 counter stopped when core is halted
+//   <o.17> DBG_TIM10_STOP           <i> TIM10 counter stopped when core is halted
+//   <o.16> DBG_TIM9_STOP            <i> TIM9 counter stopped when core is halted
+//   <o.0>  DBG_TIM1_STOP            <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.9.0
   cdefault:
 
   # List of tested compilers that can be selected

--- a/Keil.NUCLEO-F401RE_BSP.pdsc
+++ b/Keil.NUCLEO-F401RE_BSP.pdsc
@@ -21,6 +21,9 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
+      - add dbgconf files for the Blinky example.
+      - updated RTE_Components.h file.	  
     </release>
   </releases>
 

--- a/Keil.NUCLEO-F401RE_BSP.pdsc
+++ b/Keil.NUCLEO-F401RE_BSP.pdsc
@@ -21,7 +21,6 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - add dbgconf files for the Blinky example.
       - updated RTE_Components.h file.	  
     </release>


### PR DESCRIPTION
- Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0.
- Added dbgconf files to the Blinky example.
- Updated workflow, RTE_Components.h, Blinky.csolution.yml, and Keil.STM32303E-EVAL_BSP.pdsc files.